### PR TITLE
Add meetings page

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -2,6 +2,8 @@
 
 - [👋🏽 Welcome](./welcome.md)
 - [📜 Charter](./CHARTER.md)
+- [🤝 Meetings](./meetings.md)
+  - [🔍 Triage](./triage.md)
 - [🔮 The vision](./vision.md)
   - [❓How to vision](./vision/how_to_vision.md)
     - [Owning a goal or initiative](./vision/how_to_vision/owners.md)
@@ -144,7 +146,6 @@
       - [Barbara wants async read write](./vision/submitted_stories/shiny_future/barbara_wants_async_rw.md)
       - [Barbara wants async tracing](./vision/submitted_stories/shiny_future/barbara_wants_async_tracing.md)
       - [Grace debugs a crash dump again](./vision/submitted_stories/shiny_future/grace_debugs_a_crash_dump_again.md)
-- [🔍 Triage meetings](./triage.md)
 - [🔬 Design docs](./design_docs.md)
   - [⚠️ Yield-safe lint](./design_docs/yield_safe.md)
   - [☔ Stream trait](./design_docs/stream.md)

--- a/src/meetings.md
+++ b/src/meetings.md
@@ -1,0 +1,40 @@
+# Meetings
+
+We have weekly meetings with a rotating agenda for each one.
+Once a month (aspirationally on the first Thursday of the month) we have a sprint planning meeting.
+The other weeks are used for [reading club], deep dives, or whatever else we have a need for.
+Additionally, we have a [triage meeting] on every other Monday.
+
+Meetings are held either on Zulip or one of the many videoconferencing systems.
+For video meetings, we will announce each of them on the [#wg-async] Zulip stream when they are starting.
+
+All are welcome to attend any meeting!
+
+## Upcoming Meetings (September 2022)
+
+| Date       | Time       | Meeting Type    | Topic |
+|------------|------------|-----------------|-------|
+| 2022-09-01 | [09:00 PT] | Reading Club    | [A look back at asynchronous Rust](https://tomaka.medium.com/a-look-back-at-asynchronous-rust-d54d63934a1c) ([notes](https://hackmd.io/RRVC9tDVQZSKgs9JNbo5LQ))
+| 2022-09-08 | [09:00 PT] | Sprint Planning | –
+| 2022-09-12 | [08:30 PT] | Triage          | –
+| 2022-09-15 | [09:00 PT] | Reading Club    |
+| 2022-09-22 | [09:00 PT] | Reading Club    |
+| 2022-09-26 | [08:30 PT] | Triage          | –
+| 2022-09-29 | [09:00 PT] | Reading Club    |
+
+## Upcoming Meetings (October 2022)
+
+| Date       | Time       | Meeting Type    | Topic |
+|------------|------------|-----------------|-------|
+| 2022-10-06 | [09:00 PT] | Sprint Planning | –
+| 2022-10-10 | [08:30 PT] | Triage          | –
+| 2022-10-13 | [09:00 PT] | Reading Club    |
+| 2022-10-20 | [09:00 PT] | Reading Club    |
+| 2022-10-24 | [08:30 PT] | Triage          | –
+| 2022-10-27 | [09:00 PT] | Reading Club    |
+
+[reading club]: https://hackmd.io/6kSbmyggT6eAy5uvdB6srA?both
+[triage meeting]: ./triage.md
+[08:30 PT]: https://dateful.com/time-zone-converter?t=830am&tz2=PST-PDT-Pacific-Time
+[09:00 PT]: https://dateful.com/time-zone-converter?t=9am&tz2=PST-PDT-Pacific-Time
+[#wg-async]: https://rust-lang.zulipchat.com/#narrow/stream/187312-wg-async

--- a/src/triage.md
+++ b/src/triage.md
@@ -2,8 +2,10 @@
 
 ## When, where
 
-The weekly triage meeting is held on [Zulip] at [11:30 US Eastern time on Mondays][everytimezone].
+The weekly triage meeting is held on [Zulip] at [11:30 US Eastern time on every other Monday][everytimezone].
+For the date of the next triage meeting, see the [meetings page].
 
+[meetings page]: ./meetings.md
 [everytimezone]: https://everytimezone.com/s/c3abbec9
 [Zulip]: ./welcome.md#zulip
 
@@ -26,7 +28,7 @@ It is used to drive the triage process.
 
 ## Triage process
 
-In our weekly triage meetings, we take new issues assigned [`A-async-await`] and categorize them. 
+In our weekly triage meetings, we take new issues assigned [`A-async-await`] and categorize them.
 The process is:
 
 - Review the [project board], from right to left:
@@ -45,16 +47,15 @@ The process is:
 
 If an issue is a good candidate for mentoring, mark `E-needs-mentor` and try to find a mentor.
 
-Mentors assigned to issues should write up mentoring instructions. 
-**Often, this is just a couple lines pointing to the relevant code.** 
+Mentors assigned to issues should write up mentoring instructions.
+**Often, this is just a couple lines pointing to the relevant code.**
 Mentorship doesn't require intimate knowledge of the compiler, just some familiarity and a willingness to look around for the right code.
 
-After writing instructions, mentors should un-assign themselves, add `E-mentor`, and remove `E-needs-mentor`. 
-On the project board, if a mentor is assigned to an issue, it should go to the **Claimed** column until mentoring instructions are provided. 
+After writing instructions, mentors should un-assign themselves, add `E-mentor`, and remove `E-needs-mentor`.
+On the project board, if a mentor is assigned to an issue, it should go to the **Claimed** column until mentoring instructions are provided.
 After that, it should go to **To do** until someone has volunteered to work on it.
 
 [`A-async-await`]: https://github.com/rust-lang/rust/labels/A-async-await
 [uncategorized issues]: https://github.com/search?q=org%3Arust-lang+is%3Aissue+label%3AA-async-await+is%3Aopen+-label%3AAsyncAwait-Triaged&type=Issues
-[`P-high`]: https://github.com/search?q=org%3Arust-lang+is%3Aissue+label%3AAsyncAwait-Triaged+label%3AP-high+is%3Aopen&type=Issues
 [`P-medium`]: https://github.com/search?q=org%3Arust-lang+is%3Aissue+label%3AAsyncAwait-Triaged+label%3AP-medium+is%3Aopen&type=Issues
 [`P-low`]: https://github.com/search?q=org%3Arust-lang+is%3Aissue+label%3AAsyncAwait-Triaged+label%3AP-low+is%3Aopen&type=Issues

--- a/src/welcome.md
+++ b/src/welcome.md
@@ -9,7 +9,7 @@ You can learn more by reading our [charter].
 
 ## 🛠️ Getting involved
 
-There is a weekly [triage meeting] that takes place in our [Zulip stream][zulip]. Feel free to stop by then (or any time!) to introduce yourself.
+We have several [meetings] throughout the month. Feel free to stop by then (or any time!) to introduce yourself.
 
 If you're interested in fixing bugs, though, there is no need to wait for the meeting! [Take a look at the instructions here.][fix-bugs]
 
@@ -18,14 +18,12 @@ Check out the [Roadmap] to see the various things we are working on.
 Each of the high level goals should have further instructions for how to get starting helping with that goal in particular.
 Look for the 🛠️ icon, which highlights areas where further how to help resources are available.
 
-[triage meeting]: ./triage.md
+[meetings]: ./meetings.md
 [fix-bugs]: ./triage.md#so-you-want-to-fix-a-bug
 [async vision]: ./vision.md
 [Roadmap]: ./vision/roadmap.md
 
 ## Zulip
-
-[zulip]: #zulip
 
 We hold discussions on [the `#wg-async` stream in Zulip](https://rust-lang.zulipchat.com/#narrow/stream/187312-wg-async)
 
@@ -33,8 +31,8 @@ We hold discussions on [the `#wg-async` stream in Zulip](https://rust-lang.zulip
 
 Licensed under either of
 
- * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+* Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+* MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.
 
@@ -43,4 +41,3 @@ at your option.
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in this crate by you, as defined in the Apache-2.0 license, shall
 be dual licensed as above, without any additional terms or conditions.
-


### PR DESCRIPTION
To make it easier to keep track of which meetings are coming up when, we've consolidated all of our meetings details onto one page. We can also use this to schedule topics in advance.

Joint work with @tmandry 