### PR TITLE
Add a glossary

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -165,4 +165,5 @@
   - [🥞 Async Stack Traces](./design_docs/async_stack_traces.md)
 - [💬 Conversations](./conversations.md)
   - [🐦 2021-02-12 Twitter thread](./conversations/2021-02-12-Twitter-Thread.md)
+- [📖 Glossary](./glossary.md)
 - [❤️ Acknowledgments](./acknowledgments.md)

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -1,0 +1,16 @@
+# Glossary
+
+If you follow discussions in the async ecosystem you're likely to find acronyms being tossed around, many of which refer to language features that are in-progress.
+What follows is a best-effort list of those acronyms and links to resources discussing the language features.
+
+## AFIT - async fn in trait
+- [RFC #3185](https://github.com/rust-lang/rfcs/pull/3185)
+- Allows static dispatch of `async fn`s in traits
+
+## RPITIT - return position `impl trait` in traits
+- [RFC #3425](https://github.com/rust-lang/rfcs/pull/3425)
+- Allows `impl trait` as a return type in trait definitions
+
+## RTN - return type notation
+- [Tracking Issue: rust#109417](https://github.com/rust-lang/rust/issues/109417)
+- Experimental, pre-RFC feature providing bounds for return types on `async fn`s


### PR DESCRIPTION
This PR adds a glossary of acronyms commonly found in discussions of async language features. It currently just links to a couple of RFCs/issues, but could also include blog posts on these topics if we think that would be helpful.